### PR TITLE
Added opts.src and opts.dest as alternative to opts.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Express-coffee is an express middleware that automatically compiles and serves c
 #### definition.path = (string)
 The path variable is the path to your static files. Basically this is just used to map req.url onto for file paths. Requests to /javascripts/file.js will result in compilation of /coffeescripts/file.coffee
 
+#### definition.src = (string)
+Rather than specifying a 'path' you may specify a src and dest filepath.  If src is '/views' then coffeescript files will be compiled from '/views/coffeescripts/'.  If no src is specified, src will be set to the provided path option.  If neither is provided, an error will be thrown.
+
+#### definition.dest = (string)
+dest specifies the location in which to sace compiled javascript files.  If dest is '/public' then javascript files will be compiled to '/public/javascripts/'.  If no dest is specified, dest will be set to the provided path option.  If neither is provided, an error will be thrown.
+
 #### definition.live = (boolean)
 If live is enabled, the middleware will check every request if the coffeescript file has been modified recently and recompile the javascript file if it's older. Otherwise, the middleware will only check to make sure the compiled javascript file exists and serve that, regardless of age. Default is !process.env.PRODUCTION.
 

--- a/middleware.coffee
+++ b/middleware.coffee
@@ -14,18 +14,26 @@ module.exports = (opts, coffee) ->
   if typeof opts.uglify is 'undefined' then opts.uglify = live
   if typeof opts.live is 'undefined' then opts.live = !live
 
+  # determine if a single path was provided or if seperate dest and src paths were provided
+  if opts.src and opts.dest
+    # do nothing.  We're set
+  else if opts.path
+    if not opts.src     # assume src is path
+      opts.src = opts.path
+    if not opts.dest    # assume dest is path
+      opts.dest = opts.path
   # Return the middleware
   (req, res, next) ->
     # Make sure the current URL ends in either .coffee or .js
     if  !~req.url.search(/^\/javascripts/) or !~req.url.search(/.js$/) then do next
     else
-      jfile = opts.path + req.url
-      cfile = opts.path + req.url.replace(/^\/javascripts/, '/coffeescripts')
+      jfile = opts.dest + req.url
+      cfile = opts.src + req.url.replace(/^\/javascripts/, '/coffeescripts')
       cfile = cfile.replace(/.js$/, '.coffee')
       
       # Handle the final serve.
       end = (txt) ->
-        res.contentType 'javascript'
+        res.contentType 'text/javascript'
         res.header 'Content-Length', txt.length
         res.send txt
       


### PR DESCRIPTION
I wanted to store my coffeescript files in a /views directory rather than /public to match my pattern with .jade/.html and .styl/.css files.  To add this flexibility I've checked for src and dest options on construction of the compiler.  If they exist they are used instead of opts.path in the appropriate places.  Otherwise, opts.path is used.  I have not done anything special to handle the case where neither path nor src/dest is provided.

(minor) I also changed content-type from javascript to text/javascript.
