### PR TITLE
Set correct Content-Type and Content-Length

### DIFF
--- a/middleware.coffee
+++ b/middleware.coffee
@@ -33,8 +33,7 @@ module.exports = (opts, coffee) ->
       
       # Handle the final serve.
       end = (txt) ->
-        res.contentType 'text/javascript'
-        res.header 'Content-Length', txt.length
+        res.contentType 'js'
         res.send txt
       
       # Yup, we have to (re)compile.


### PR DESCRIPTION
res.contentType() was interpreted 'text/javascripts' as
'application/octet-stream' by mime package. Use 'js' instead.

Content-Length should care abount multi-type chars. It is handled
automatically by request.js in express. It can be omitted.
